### PR TITLE
Fix spacing issue before commas

### DIFF
--- a/src/templates/_components/widgets/RecentchangesWidget_body.twig
+++ b/src/templates/_components/widgets/RecentchangesWidget_body.twig
@@ -24,10 +24,10 @@
                         <a href="{{ entry.getCpEditUrl() }}">{{ entry.title }}</a>
                         <span class="light">
                             {{ entry.dateUpdated|timestamp('short') }}
-                            {% if CraftEdition == CraftPro %}
-                                {% if className == "craft\\models\\EntryVersion" %}
+                            {%- if CraftEdition == CraftPro -%}
+                                {% if className == "craft\\models\\EntryVersion" -%}
                                     , {{ entry.getCreator().username }}
-                                {% elseif className == "craft\\elements\\Entry" %}
+                                {% elseif className == "craft\\elements\\Entry" -%}
                                     , {{ entry.author.username }}
                                 {% endif %}
                             {% endif %}


### PR DESCRIPTION
Thanks for this plugin!

The change widgets have a leading space before the comma, eg:

![image](https://user-images.githubusercontent.com/394376/54987132-e74b8980-4fab-11e9-8a1f-2af058a94330.png)

This change swallows some of the whitespace so it matches the formatting of the existing Recent Entries widget:

![image](https://user-images.githubusercontent.com/394376/54987172-ff230d80-4fab-11e9-904c-689791f0c304.png)

Minor thing, but it was bugging me!